### PR TITLE
Fix "initBrowser is not a function"

### DIFF
--- a/example/app/ld.server.tsx
+++ b/example/app/ld.server.tsx
@@ -1,4 +1,4 @@
-import { initLDServerClient } from 'remix-sdk'
+import { initLDServerClient, renderFlagsToString } from 'remix-sdk'
 import { v4 } from 'uuid'
 let client = undefined;
 
@@ -7,6 +7,6 @@ const createClient = async (): Promise<string> => {
     return v4()
 }
 
-export { createClient }
+export { createClient, renderFlagsToString  }
 
 

--- a/example/app/root.tsx
+++ b/example/app/root.tsx
@@ -1,8 +1,7 @@
 import type { MetaFunction, LoaderFunction } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
-import { renderFlagsToString } from 'remix-sdk';
-import { createClient } from './ld.server'
+import { createClient, renderFlagsToString } from './ld.server'
 export const meta: MetaFunction = () => ({
   charset: 'utf-8',
   title: 'New Remix App',


### PR DESCRIPTION
I am still not entirely sure why this works but it seems like remix is doing some fancy bundling work  