### PR TITLE
fix ts errors when remix-sdk client is imported

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,17 @@
+import { LDClient, LDFlagSet, LDUser } from 'launchdarkly-js-client-sdk';
+
 import useFlags from '../shared/useFlags';
 import useLDUser from '../shared/useLDUser';
 
 import LDBrowser from './ldBrowser';
+
+declare global {
+  interface Window {
+    ldClientBrowser: LDClient;
+    ssrFlags: LDFlagSet;
+    ldUser: LDUser;
+    clientSideID: string;
+  }
+}
 
 export { LDBrowser, useFlags, useLDUser };

--- a/src/client/ldBrowser.tsx
+++ b/src/client/ldBrowser.tsx
@@ -1,11 +1,10 @@
-import React, { Component, ReactNode } from 'react';
+import { Component, ReactNode } from 'react';
 import { initialize, LDFlagChangeset, LDFlagSet } from 'launchdarkly-js-client-sdk';
 
 import { LDContext as HocState, Provider } from '../shared/context';
 import { getFlattenedFlagsFromChangeset } from '../shared/utils';
 
 type LDBrowserProps = { children: ReactNode };
-
 class LDBrowser extends Component<LDBrowserProps, HocState> {
   readonly state: Readonly<HocState>;
 
@@ -31,6 +30,7 @@ class LDBrowser extends Component<LDBrowserProps, HocState> {
   }
 
   render() {
+    // eslint-disable-next-line react/react-in-jsx-scope
     return <Provider value={this.state}>{this.props.children}</Provider>;
   }
 }

--- a/src/shared/context.ts
+++ b/src/shared/context.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { LDClient as LDJSClient, LDUser, LDFlagSet } from 'launchdarkly-js-client-sdk';
+import type { LDClient as LDJSClient, LDFlagSet, LDUser } from 'launchdarkly-js-client-sdk';
 
 interface LDContext {
   flags: LDFlagSet;
@@ -10,5 +10,6 @@ interface LDContext {
 const context = createContext<LDContext>({ flags: {}, ldClient: undefined, user: undefined });
 const { Provider, Consumer } = context;
 
-export { Provider, Consumer, LDContext };
+export { Provider, Consumer };
+export type { LDContext };
 export default context;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Fixing type errors that are thrown when the `remix-sdk` client exports are pulled into a project with stricter `tsconfig` options and imported via:

`import { useFlags } from 'node_modules/remix-sdk/src/client';`

 My project is using `typescript@4.7.4`. Right now, projects with stricter TS settings can throw these errors:

1:
```
node_modules/remix-sdk/src/client/ldBrowser.tsx:1:8 - error TS6133: 'React' is declared but its value
is never read.

1 import React, { Component, ReactNode } from 'react';
         ~~~~~
```

2, 3, 4:
```
node_modules/remix-sdk/src/client/ldBrowser.tsx:14:13 - error TS2339: Property 'ssrFlags' does not
exist on type 'Window & typeof globalThis'.

14     const { ssrFlags, clientSideID, ldUser } = window;
               ~~~~~~~~

node_modules/remix-sdk/src/client/ldBrowser.tsx:14:23 - error TS2339: Property 'clientSideID' does not
exist on type 'Window & typeof globalThis'.

14     const { ssrFlags, clientSideID, ldUser } = window;
                         ~~~~~~~~~~~~

node_modules/remix-sdk/src/client/ldBrowser.tsx:14:37 - error TS2339: Property 'ldUser' does not
exist on type 'Window & typeof globalThis'.

14     const { ssrFlags, clientSideID, ldUser } = window;
                                       ~~~~~~
```

5:
```
node_modules/remix-sdk/src/shared/context.ts:13:30 - error TS1205: Re-exporting a type
when the '--isolatedModules' flag is provided requires using 'export type'.

13 export { Provider, Consumer, LDContext };
```