### PR TITLE
Export useClient from shared.

### DIFF
--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,4 +1,5 @@
 import LDScript from './ldScript';
 import useFlags from './useFlags';
+import useClient from './useClient';
 
-export { LDScript, useFlags };
+export { LDScript, useFlags, useClient };

--- a/src/shared/useClient.ts
+++ b/src/shared/useClient.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+
+import context from './context';
+
+const useClient = () => {
+  const { ldClient } = useContext(context);
+  return ldClient;
+};
+
+export default useClient;


### PR DESCRIPTION
Adding a useClient hook to export the client from base. This is in line with the React client.