### PR TITLE
fix: no-op setState before mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "LaunchDarkly SDK for Remix",
   "keywords": [
     "launchdarkly",
@@ -10,12 +10,6 @@
     "sdk",
     "remix"
   ],
-  "exports": {
-    "./client": "./lib/client/index.js",
-    "./server": "./lib/server/index.js",
-    "./shared": "./lib/shared/index.js"
-  },
-  "types": "lib/index.d.ts",
   "files": [
     "lib",
     "src"

--- a/src/client/ldBrowser.tsx
+++ b/src/client/ldBrowser.tsx
@@ -1,38 +1,54 @@
-import React, { Component, ReactNode } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { initialize, LDFlagChangeset, LDFlagSet } from 'launchdarkly-js-client-sdk';
 
-import { LDContext as HocState, Provider } from '../shared/context';
+import { Provider } from '../shared/context';
 import { getFlattenedFlagsFromChangeset } from '../shared/utils';
 
 type LDBrowserProps = { children: ReactNode };
 
-class LDBrowser extends Component<LDBrowserProps, HocState> {
-  readonly state: Readonly<HocState>;
+const LDBrowser = ({ children }: LDBrowserProps) => {
+  const { ssrFlags, clientSideID, ldUser } = window;
+  console.log(`initializing ld client with ${clientSideID}...`);
+  const ldClient = initialize(clientSideID, ldUser, { bootstrap: ssrFlags });
+  const [ldData, setLDData] = useState({
+    flags: ssrFlags,
+    ldClient,
+    user: ldUser,
+  });
 
-  constructor(props: LDBrowserProps) {
-    super(props);
-    const { ssrFlags, clientSideID, ldUser } = window;
+  useEffect(() => {
+    const onChange = (changes: LDFlagChangeset) => {
+      const flattened: LDFlagSet = getFlattenedFlagsFromChangeset(
+        changes,
+        ssrFlags
+      );
 
-    console.log(`initializing ld client with ${clientSideID}...`);
-    const ldClient = initialize(clientSideID, ldUser, { bootstrap: ssrFlags });
-
-    ldClient.on('change', (changes: LDFlagChangeset) => {
-      const flattened: LDFlagSet = getFlattenedFlagsFromChangeset(changes, ssrFlags);
       if (Object.keys(flattened).length > 0) {
-        this.setState(({ flags }) => ({ flags: { ...flags, ...flattened } }));
+        setLDData({
+          ...ldData,
+          flags: {
+            ...ldData.flags,
+            ...flattened,
+          },
+        });
       }
-    });
-
-    this.state = {
-      flags: ssrFlags,
-      ldClient,
-      user: ldUser,
     };
-  }
+    ldClient.on("change", onChange);
 
-  render() {
-    return <Provider value={this.state}>{this.props.children}</Provider>;
-  }
-}
+    return () => {
+      ldClient.off("change", onChange);
+    };
+  }, []);
+
+  
+  return (
+    <Provider
+      value={ldData}
+    >
+      {children}
+    </Provider>
+  );
+};
+
 
 export default LDBrowser;


### PR DESCRIPTION
When using the current `LDBrowser` provider it lead to the following error with Remix: 

```
Can't call setState on a component that is not yet mounted. This is a no-op, but it might indicate a bug in your application. 
```

Re-writing the `LDBrowser` as a functional component fixed it. 
